### PR TITLE
improve wording of PartOfDay

### DIFF
--- a/pkg/ui/model.go
+++ b/pkg/ui/model.go
@@ -55,7 +55,7 @@ func (m model) View() string {
 	for _, l := range uhr.Uhr(m.t) {
 		s += list.Render("- ") + italic.Render(l) + "\n"
 	}
-	s += "Es ist in " + italic.Render(uhr.PartOfDay(m.t)) + ".\n"
+	s += "Es ist " + italic.Render(uhr.PartOfDay(m.t)) + ".\n"
 
 	s += footer.Render("\npress 'q' to quit")
 	return s

--- a/uhr.go
+++ b/uhr.go
@@ -92,18 +92,18 @@ type Hourer interface {
 func PartOfDay(h Hourer) string {
 	t := h.Hour()
 	if t >= 6 && t < 12 {
-		return "der Morgen"
+		return "am Morgen"
 	}
 	if t >= 12 && t < 14 {
-		return "der Mittag"
+		return "am Mittag"
 	}
 	if t >= 14 && t < 18 {
-		return "der Nachmittag"
+		return "am Nachmittag"
 	}
 	if t >= 18 && t < 22 {
-		return "der Abend"
+		return "am Abend"
 	}
-	return "die Nacht"
+	return "in der Nacht"
 }
 
 type Weekdayer interface {


### PR DESCRIPTION
Hi Carlos,

The wording of `PartOfDay()` could be improved using the following phrases. While the used articles were correct, germans dont really say `Es ist in die Nacht`, more widely used is something like `Es ist in der Nacht`, `Es ist am Nachmittag`. Here I found some explanations and examples: https://deutschlernerblog.de/tagesablauf-auf-deutsch-deutsch-lernen-a1-thema-8/

Viel Erfolg und viel Spaß weiterhin beim Deutsch lernen :) 